### PR TITLE
Markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Author: Stefan Frunza
 <p><strong>THIS PROGRAM DELETES THE TARGET DIRECTORY SPECIFIED WITH THE -o OPTION.</strong> it then recreates it and populates it with the new HTML, but remember <strong>THIS PROGRAM DELETES THE TARGET DIRECTORY SPECIFIED WITH THE -o OPTION.</strong></p>
 
 <H1>What it is</H1>
-<p>A tool that will take a text file as an option and create HTML markup based upon it.<br>
+<p>A tool that will take a text (.txt) or markdown (.md) file as an option and create HTML markup based upon it.<br>
 To use simply open a console to the script's location and write <strong>python Sitegen.py</strong> along with the options you wish to specify, among which you must have a plain text file to convert to mark up.</p>
 
 
@@ -31,3 +31,9 @@ To use simply open a console to the script's location and write <strong>python S
 | -i | --input | Specify an Input directory or file only .txt suffix will be correctly parsed (requires argument) |
 | -o | --ouput | Specify a name for existing directory (optional argument)|
 
+<h2>Markdown Support:</h2>
+
+| Type | Or | Result |
+| -------- | -------- | ------ |
+| \*Italic\* | \_Italic\_ | <i>Italic</i>  |
+| \*\*Bold\*\* | \_\_Bold\_\_ | <b>Bold</b>  |

--- a/SSJ.py
+++ b/SSJ.py
@@ -47,26 +47,26 @@ class SSJ:
                     if line != "\n":
                         titleQuestionMark = False
                         newLine = "<p>" + titleStorage 
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                         newLine =  line 
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                 elif i == 2:
                     if line != "\n":
                         titleQuestionMark = False
                         newLine = "<p>" + titleStorage + "</p>"
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                         newLine = "<p>" + line 
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                 elif i == 3:
                     if titleQuestionMark == True:
                         newLine = "<h1>" + titleStorage + "</h1>"
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                         newLine = "<p>" + line 
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                 else:
                     if line == "\n":
                         newLine = "</p>" + "<p>"
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
                     else:
                         newLine = line
                         paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
@@ -133,25 +133,22 @@ class SSJ:
             
         SSJ.template = temp
 
+    def markdownSearch(regex, indChars, tag, line):
+        newLine = line
+        match = re.search(regex,newLine)
+        while match != None:
+            newLine = newLine[:match.span()[0]] + "<" + tag + ">" + newLine[match.span()[0]+indChars:match.span()[1]-indChars] + "</"+ tag +">" + newLine[match.span()[1]:]
+            match = re.search(regex,newLine)
+        return newLine
+
     def convertMarkdown(line):
         newLine = line
-
-        #need to reduce code repetition
-        #italics
-        match = re.search("\*[^*]+\*",newLine)
-        if match != None:
-            newLine = newLine[:match.span()[0]] + "<i>" + newLine[match.span()[0]+1:match.span()[1]-1] + "</i>" + newLine[match.span()[1]:]
-
-        match = re.search("_[^*]+_",newLine)
-        if match != None:
-            newLine = newLine[:match.span()[0]] + "<i>" + newLine[match.span()[0]+1:match.span()[1]-1] + "</i>" + newLine[match.span()[1]:]
-
         #bold
-        match = re.search("\*\*[^*]+\*\*",newLine)
-        if match != None:
-            newLine = newLine[:match.span()[0]] + "<b>" + newLine[match.span()[0]+2:match.span()[1]-2] + "</b>" + newLine[match.span()[1]:]
-        match = re.search("\*\*[^*]+\*\*",newLine)
-        if match != None:
-            newLine = newLine[:match.span()[0]] + "<b>" + newLine[match.span()[0]+2:match.span()[1]-2] + "</b>" + newLine[match.span()[1]:]
+        newLine = SSJ.markdownSearch("\*\*[^*]+\*\*", 2, "b", newLine)
+        newLine = SSJ.markdownSearch("__[^*]+__", 2, "b", newLine)
+        #italics
+        newLine = SSJ.markdownSearch("\*[^*]+\*", 1, "i", newLine)
+        newLine = SSJ.markdownSearch("_[^*]+_", 1, "i", newLine)
+
 
         return newLine

--- a/SSJ.py
+++ b/SSJ.py
@@ -1,5 +1,6 @@
 from os import listdir
 from os.path import isfile, join
+import re
 
 class SSJ:
     defaultOutputFolder = "./dist"
@@ -68,7 +69,7 @@ class SSJ:
                         paragraphs.append(newLine)
                     else:
                         newLine = line
-                        paragraphs.append(newLine)
+                        paragraphs.append(SSJ.convertMarkdown(newLine) if inputFile.endswith(".md") else newLine)
             #print (paragraphs)
             
             outputName = inputFile[:inputFile.find('.')] + '.html'
@@ -131,3 +132,26 @@ class SSJ:
             print("Error: " + str(err)) 
             
         SSJ.template = temp
+
+    def convertMarkdown(line):
+        newLine = line
+
+        #need to reduce code repetition
+        #italics
+        match = re.search("\*[^*]+\*",newLine)
+        if match != None:
+            newLine = newLine[:match.span()[0]] + "<i>" + newLine[match.span()[0]+1:match.span()[1]-1] + "</i>" + newLine[match.span()[1]:]
+
+        match = re.search("_[^*]+_",newLine)
+        if match != None:
+            newLine = newLine[:match.span()[0]] + "<i>" + newLine[match.span()[0]+1:match.span()[1]-1] + "</i>" + newLine[match.span()[1]:]
+
+        #bold
+        match = re.search("\*\*[^*]+\*\*",newLine)
+        if match != None:
+            newLine = newLine[:match.span()[0]] + "<b>" + newLine[match.span()[0]+2:match.span()[1]-2] + "</b>" + newLine[match.span()[1]:]
+        match = re.search("\*\*[^*]+\*\*",newLine)
+        if match != None:
+            newLine = newLine[:match.span()[0]] + "<b>" + newLine[match.span()[0]+2:match.span()[1]-2] + "</b>" + newLine[match.span()[1]:]
+
+        return newLine

--- a/SSJ.py
+++ b/SSJ.py
@@ -37,7 +37,7 @@ class SSJ:
             
             
             Lines = file.readlines()
-        
+            
             for i, line in enumerate(Lines):
                 #my logic doesnt work. I need it to be blank line delimiter.
                 if i == 0:
@@ -71,7 +71,7 @@ class SSJ:
                         paragraphs.append(newLine)
             #print (paragraphs)
             
-            outputName = inputFile[:inputFile.find('.txt')] + '.html'
+            outputName = inputFile[:inputFile.find('.')] + '.html'
             
             print("new name:", outputName)
             
@@ -115,9 +115,9 @@ class SSJ:
         SSJ.template = SSJ.template.replace("Filename", "Index Page")
         
         for file in onlyfiles:
-            if file.endswith(".txt"):
+            if file.endswith(".txt") or file.endswith(".md"):
                 self.parseFile(file, inputFolder)
-                outputName = (file[:file.find('.txt')] + '.html')
+                outputName = (file[:file.find('.')] + '.html')
                 hrefName = outputName.replace(" ", "%20")
                 pos = SSJ.template.find(SSJ.token) + len(SSJ.token)
                 SSJ.template = SSJ.template[:pos] + "<a href={}>{}</a><br>".format(hrefName, outputName) + SSJ.template[pos:]

--- a/Sitegen.py
+++ b/Sitegen.py
@@ -37,7 +37,7 @@ def main(argv):
         
     os.mkdir(SiteGen.output)
 
-    if SiteGen.input.endswith(".txt"):
+    if SiteGen.input.endswith(".txt") or SiteGen.input.endswith(".md") :
         SiteGen.parseFile(input)
     elif isdir(SiteGen.input):
         SiteGen.parseDir(input)


### PR DESCRIPTION
Fixes #4

I added: 

- support for reading `.md` files, both from an input directory and input file
- reading bold markdown indicators
- reading italic markdown indicators

I attempted to change as little of the original source code as possible. I used regex to search for the markdown indicators and index slicing to remove the indicators that were replaced by HTML tags. There is some code repetition that needs to be resolved on the function that I added to convert markdown indicators to the appropriate HTML tags. 