### PR TITLE
Issue 8

### DIFF
--- a/SSJ.py
+++ b/SSJ.py
@@ -170,8 +170,13 @@ class SSJ:
         arrOfStr = [''] * 2
         
         if (data['input']):
-            arrOfStr[0] = data['input']
+           arrOfStr[0] = data['input']
+        else:
+            arrOfStr[0] = "./dist"
+
         if (data['output']):
             arrOfStr[1] = data['output']
+        else:
+            arrOfStr[0] = "./output"
 
         return arrOfStr

--- a/SSJ.py
+++ b/SSJ.py
@@ -1,6 +1,6 @@
 from os import listdir
 from os.path import isfile, join
-import re
+import re, json
 
 class SSJ:
     defaultOutputFolder = "./dist"
@@ -163,4 +163,8 @@ class SSJ:
         return newLine
 
     def parseConfig(configFile, input, output):
+        with open("tutswiki.json", "r") as jsonfile:
+            data = json.load(jsonfile)
+            print("Read successful")
+        print(data)
         return 0

--- a/SSJ.py
+++ b/SSJ.py
@@ -162,9 +162,16 @@ class SSJ:
 
         return newLine
 
-    def parseConfig(configFile, input, output):
+    def parseConfig(self, configFile):
         with open(configFile, "r") as jsonfile:
             data = json.load(jsonfile)
             print("Read successful")
-        print(data)
-        return 0
+
+        arrOfStr = [''] * 2
+        
+        if (data['input']):
+            arrOfStr[0] = data['input']
+        if (data['output']):
+            arrOfStr[1] = data['output']
+
+        return arrOfStr

--- a/SSJ.py
+++ b/SSJ.py
@@ -161,3 +161,6 @@ class SSJ:
         newLine = SSJ.markdownSearch("\-\-\-[^*]", 3, "hr", newLine)
 
         return newLine
+
+    def parseConfig(configFile, input, output):
+        return 0

--- a/SSJ.py
+++ b/SSJ.py
@@ -163,7 +163,7 @@ class SSJ:
         return newLine
 
     def parseConfig(configFile, input, output):
-        with open("tutswiki.json", "r") as jsonfile:
+        with open(configFile, "r") as jsonfile:
             data = json.load(jsonfile)
             print("Read successful")
         print(data)

--- a/Sitegen.py
+++ b/Sitegen.py
@@ -8,20 +8,30 @@ def main(argv):
 
 
     try:
-        opts, args = getopt.getopt(argv, "vhi:o:", ["version", "help", "input=", "output="])
+        opts, args = getopt.getopt(argv, "vhi:o:c:", ["version", "help", "input=", "output=", "config="])
     except getopt.GetoptError:
         print ('Error with GetOpt')
         sys.exit(2)
 
+    configExists = 0
+
     for opt, arg in opts:
-        if opt in ("-v", "--version"):
-           print ("Name: " + name, "\nVersion: " + version)  
-        elif opt in ("-h", "--help"):
-            print("This tool is designed to take a plain text file and generate a HTML markup file based upon it.\nPossible options:\n -i or --input to specify an input file\n -o or --output to specify the name of a specific directory you would like to output to (it must be an existing valid directory).\n -v or --version to see the name and version of the tool\n")
-        elif opt in ("-i", "--input"):
-            input = arg
-        elif opt in ("-o", "--output"):
-            output = arg 
+        if opt in ("-c", "--config"):
+            configExists = 1
+
+    if (configExists == 1):
+        print("config file")
+
+    if (configExists == 0):
+        for opt, arg in opts:
+            if opt in ("-v", "--version"):
+                print ("Name: " + name, "\nVersion: " + version)  
+            if opt in ("-h", "--help"):
+                print("This tool is designed to take a plain text file and generate a HTML markup file based upon it.\nPossible options:\n -i or --input to specify an input file\n -o or --output to specify the name of a specific directory you would like to output to (it must be an existing valid directory).\n -v or --version to see the name and version of the tool\n")
+            if opt in ("-i", "--input"):
+                input = arg
+            if opt in ("-o", "--output"):
+                output = arg 
     
     if 'output' in locals():
         SiteGen = SSJ(input, output)

--- a/Sitegen.py
+++ b/Sitegen.py
@@ -17,10 +17,14 @@ def main(argv):
 
     for opt, arg in opts:
         if opt in ("-c", "--config"):
+            config = arg
             configExists = 1
+            break
 
     if (configExists == 1):
-        print("config file")
+        if os.path.exists(config) and config.endswith(".json"):
+            SiteGen = SSJ
+            SiteGen.parseConfig(config, input, output)
 
     if (configExists == 0):
         for opt, arg in opts:

--- a/Sitegen.py
+++ b/Sitegen.py
@@ -23,8 +23,11 @@ def main(argv):
 
     if (configExists == 1):
         if os.path.exists(config) and config.endswith(".json"):
-            SiteGen = SSJ
-            SiteGen.parseConfig(config, input, output)
+            configOpts = SSJ.parseConfig(SSJ, config)
+            if configOpts[0] != '':
+                input = configOpts[0]
+            if configOpts[1] !='':
+                output = configOpts[1]
 
     if (configExists == 0):
         for opt, arg in opts:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "input": "./site",
+  "output": "./build",
+  "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
+  "lang": "fr"
+}


### PR DESCRIPTION
Implemented support for reading a JSON config file.

Code can now accept the `--config -c` flag in the command line matching the requirements as described in the [Lab 4 instructions.](https://github.com/Seneca-CDOT/topics-in-open-source-2022/wiki/lab-4#requirements)

If the program is executed with the `--config` flag, all other flags will be ignored.
If the `--config` flag is not followed by an argument, the program will exit with an error.